### PR TITLE
update calling busted

### DIFF
--- a/tools/unittest.lua
+++ b/tools/unittest.lua
@@ -9,6 +9,7 @@ drystal = require 'drystal'
 os.exit = drystal.stop
 
 require 'busted.runner' {
+	standalone=false,
 	batch=true,
 }
 


### PR DESCRIPTION
Busted 2.0.rc11-0 has the following main file:

``` lua
require 'busted.runner'({ standalone = false })
```

Previous Busted versions had batch = true instead of standalone = false.
Use both of them to be compatible with both Busted versions.
